### PR TITLE
Display line number even if filename is unknown

### DIFF
--- a/yara-python.c
+++ b/yara-python.c
@@ -1650,7 +1650,8 @@ void raise_exception_on_error(
     else
       PyErr_Format(
           YaraSyntaxError,
-          "%s",
+          "line %d: %s",
+          line_number,
           message);
   }
 }
@@ -1675,7 +1676,8 @@ void raise_exception_on_error_or_warning(
     else
       PyErr_Format(
           YaraSyntaxError,
-          "%s",
+          "line %d: %s",
+          line_number,
           message);
   }
   else
@@ -1690,7 +1692,8 @@ void raise_exception_on_error_or_warning(
     else
       PyErr_Format(
           YaraWarningError,
-          "%s",
+          "line %d: %s",
+          line_number,
           message);
   }
 }


### PR DESCRIPTION
When rules are passed as strings, the line number would not be shown
when input as a string. The information is available however.