### PR TITLE
Check if file is actually a file object

### DIFF
--- a/yara-python.c
+++ b/yara-python.c
@@ -1829,9 +1829,16 @@ static PyObject* yara_compile(
     else if (file != NULL)
     {
       fd = dup(PyObject_AsFileDescriptor(file));
-      fh = fdopen(fd, "r");
-      error = yr_compiler_add_file(compiler, fh, NULL, NULL);
-      fclose(fh);
+      if (fd != -1) {
+        fh = fdopen(fd, "r");
+        error = yr_compiler_add_file(compiler, fh, NULL, NULL);
+        fclose(fh);
+      }
+      else {
+        result = PyErr_Format(
+            PyExc_TypeError,
+            "'file' is not a file object");
+      }
     }
     else if (sources_dict != NULL)
     {


### PR DESCRIPTION
If it is not a file like object, the function would return -1. This
would eventually lead to a segmention fault later on.