### PR TITLE
Add LICENSE to MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,4 @@
 include *.c
 include yara/libyara/modules/module_list
 recursive-include yara *.c *.h
+include LICENSE


### PR DESCRIPTION
The 3.6.0 source tarball does not contain the LICENSE, and so building yara-python fails. This PR adds LICENSE to MANIFEST.in so that it is included in the source tarball.

[Failing build log](https://gist.github.com/gmacon/17f93f7b9bbb356f2458a2eb5a6cd066)