### PR TITLE
Add missing openssl include path.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -201,6 +201,7 @@ class BuildExtCommand(build_ext):
         if (has_function('MD5_Init', libraries=['crypto']) and
             has_function('SHA256_Init', libraries=['crypto'])):
           module.define_macros.append(('HASH_MODULE', '1'))
+          module.define_macros.append(('HAVE_LIBCRYPTO', '1'))
           module.libraries.append('crypto')
         else:
           exclusions.append('yara/libyara/modules/hash.c')

--- a/setup.py
+++ b/setup.py
@@ -178,6 +178,7 @@ class BuildExtCommand(build_ext):
       module.libraries.append('ws2_32')
 
     if building_for_osx:
+      module.include_dirs.append('/usr/local/opt/openssl/include')
       module.include_dirs.append('/opt/local/include')
       module.library_dirs.append('/opt/local/lib')
       module.include_dirs.append('/usr/local/include')


### PR DESCRIPTION
On my system openssl (via brew) is installed in /usr/local/opt/openssl/include, which was causing the build to fail. I'm not sure if my system is just in a screwed up state or if this is causing pain for others.