### PR TITLE
Return ERROR_CALLBACK_ERROR instead of CALLBACK_ERROR.

### DIFF
--- a/yara-python.c
+++ b/yara-python.c
@@ -666,7 +666,7 @@ int yara_callback(
     }
     else
     {
-      result = CALLBACK_ERROR;
+      result = ERROR_CALLBACK_ERROR;
     }
 
     Py_DECREF(module_info_dict);


### PR DESCRIPTION
This allows exceptions thrown in the modules_callback to be properly thrown, instead of silently eaten.