### PR TITLE
Iterator reset for Rules object 

### DIFF
--- a/yara-python.c
+++ b/yara-python.c
@@ -1278,6 +1278,7 @@ static PyObject* Rules_next(
 
   if (RULE_IS_NULL(rules->iter_current_rule))
   {
+    rules->iter_current_rule = rules->rules->rules_list_head;
     PyErr_SetNone(PyExc_StopIteration);
     return NULL;
   }


### PR DESCRIPTION
This change makes it so that when iterating over a Rules object, the iteration is reset once all rules have been iterated over.