### PR TITLE
Fix segfault at error in match string

### DIFF
--- a/yara-python.c
+++ b/yara-python.c
@@ -1499,7 +1499,18 @@ static PyObject* Rules_match(
 
       if (error != ERROR_CALLBACK_ERROR)
       {
-        handle_error(error, filepath);
+        if (filepath != NULL)
+        {
+          handle_error(error, filepath);
+        }
+        else if (data != NULL)
+        {
+          handle_error(error, "<data>");
+        }
+        else if (pid != 0)
+        {
+          handle_error(error, "<proc>");
+        }
 
         #ifdef PROFILING_ENABLED
         PyObject* exception = PyErr_Occurred();


### PR DESCRIPTION
If Yara return error for `rules.match(data='string')` the Python wrapper module crashes process with a segmentation fault.
Handle properly errors from 'data' and from 'pid'.