### PR TITLE
Callback on include

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,3 @@
 [submodule "yara"]
-	path = yara
-	url=https://edhoedt@github.com/edhoedt/yara
-	branch = callback_on_include
+path = yara	
+url=https://plusvic@github.com/VirusTotal/yara.git

--- a/tests.py
+++ b/tests.py
@@ -836,6 +836,16 @@ class TestYara(unittest.TestCase):
 
         self.assertTrue(rule_data['rule'] == 'test')
 
+    def testIncludeCallback(self):
+
+        def callback(requested_filename, filename, namespace):
+            if requested_filename == 'foo':
+                return 'rule included {condition: true }'
+            return None
+
+        r = yara.compile(source='include "foo" rule r { condition: included }', include_callback=callback)
+        self.assertTrue(r.match(data='dummy'))
+
     def testCompare(self):
 
         r = yara.compile(sources={

--- a/yara-python.c
+++ b/yara-python.c
@@ -1902,10 +1902,12 @@ static PyObject* yara_compile(
     {
       if (!PyCallable_Check(include_callback))
       {
+        yr_compiler_destroy(compiler);
         return PyErr_Format(
             PyExc_TypeError,
             "'include_callback' must be callable");
       }
+
       Py_INCREF(include_callback);
       yr_compiler_set_include_callback(compiler,
                                        yara_include_callback,

--- a/yara-python.c
+++ b/yara-python.c
@@ -1716,11 +1716,13 @@ void raise_exception_on_error_or_warning(
 ////////////////////////////////////////////////////////////////////////////////
 
 const char* yara_include_callback(
-  const char* include_name,
-  const char* calling_rule_filename,
-  const char* calling_rule_namespace,
-  void* user_data)
+    const char* include_name,
+    const char* calling_rule_filename,
+    const char* calling_rule_namespace,
+    void* user_data)
 {
+  const char* cstring_result = NULL;
+
   PyObject* callback = (PyObject*) user_data;
   PyObject* py_incl_name = NULL;
   PyObject* py_calling_fn = NULL;
@@ -1758,22 +1760,27 @@ const char* yara_include_callback(
     Py_INCREF(py_calling_ns);
   }
 
-  Py_INCREF(callback);
+
   PyObject *type=NULL, *value=NULL, *traceback=NULL;
   PyErr_Fetch(&type, &value, &traceback);
-  PyObject* result =  PyObject_CallFunctionObjArgs(callback,
-                                                   py_incl_name,
-                                                   py_calling_fn,
-                                                   py_calling_ns,
-                                                   NULL);
-  PyErr_Restore(type, value, traceback);
+
+  Py_INCREF(callback);
+
+  PyObject* result =  PyObject_CallFunctionObjArgs(
+      callback,
+      py_incl_name,
+      py_calling_fn,
+      py_calling_ns,
+      NULL);
 
   Py_DECREF(callback);
+
+  PyErr_Restore(type, value, traceback);
+
   Py_DECREF(py_incl_name);
   Py_DECREF(py_calling_fn);
   Py_DECREF(py_calling_ns);
 
-  const char* cstring_result = NULL;
   if (result != NULL && result != Py_None && PY_STRING_CHECK(result))
   {
     //transferring string ownership to C code

--- a/yara-python.c
+++ b/yara-python.c
@@ -1735,7 +1735,9 @@ const char* yara_include_callback(
   else //safeguard: should never happen for 'include_name'
   {
     py_incl_name = Py_None;
+    Py_INCREF(py_incl_name);
   }
+
   if (calling_rule_filename != NULL)
   {
     py_calling_fn = PY_STRING(calling_rule_filename);
@@ -1743,7 +1745,9 @@ const char* yara_include_callback(
   else
   {
     py_calling_fn = Py_None;
+    Py_INCREF(py_calling_fn);
   }
+
   if (calling_rule_namespace != NULL)
   {
     py_calling_ns = PY_STRING(calling_rule_namespace);
@@ -1751,6 +1755,7 @@ const char* yara_include_callback(
   else
   {
     py_calling_ns = Py_None;
+    Py_INCREF(py_calling_ns);
   }
 
   Py_INCREF(callback);

--- a/yara-python.c
+++ b/yara-python.c
@@ -1763,16 +1763,12 @@ const char* yara_include_callback(
   PyObject *type=NULL, *value=NULL, *traceback=NULL;
   PyErr_Fetch(&type, &value, &traceback);
 
-  Py_INCREF(callback);
-
   PyObject* result = PyObject_CallFunctionObjArgs(
       callback,
       py_incl_name,
       py_calling_fn,
       py_calling_ns,
       NULL);
-
-  Py_DECREF(callback);
 
   PyErr_Restore(type, value, traceback);
 

--- a/yara-python.c
+++ b/yara-python.c
@@ -1760,13 +1760,12 @@ const char* yara_include_callback(
     Py_INCREF(py_calling_ns);
   }
 
-
   PyObject *type=NULL, *value=NULL, *traceback=NULL;
   PyErr_Fetch(&type, &value, &traceback);
 
   Py_INCREF(callback);
 
-  PyObject* result =  PyObject_CallFunctionObjArgs(
+  PyObject* result = PyObject_CallFunctionObjArgs(
       callback,
       py_incl_name,
       py_calling_fn,
@@ -1920,11 +1919,11 @@ static PyObject* yara_compile(
             "'include_callback' must be callable");
       }
 
-      Py_INCREF(include_callback);
-      yr_compiler_set_include_callback(compiler,
-                                       yara_include_callback,
-                                       yara_include_free,
-                                       include_callback);
+      yr_compiler_set_include_callback(
+          compiler,
+          yara_include_callback,
+          yara_include_free,
+          include_callback);
     }
 
     if (externals != NULL && externals != Py_None)
@@ -1945,6 +1944,8 @@ static PyObject* yara_compile(
             "'externals' must be a dictionary");
       }
     }
+
+    Py_XINCREF(include_callback);
 
     if (filepath != NULL)
     {
@@ -2098,8 +2099,9 @@ static PyObject* yara_compile(
     }
 
     yr_compiler_destroy(compiler);
+    Py_XDECREF(include_callback);
   }
-  Py_XDECREF(include_callback);
+
   return result;
 }
 

--- a/yara-python.c
+++ b/yara-python.c
@@ -1776,12 +1776,14 @@ const char* yara_include_callback(
   }
   else
   {
-    if(PyErr_Occurred() == NULL)
+    if (PyErr_Occurred() == NULL)
     {
-      PyErr_Format(PyExc_TypeError, "'include_callback' callback function must return a yara rule or rules set formated as a single ascii or unicode string");
+      PyErr_Format(PyExc_TypeError,
+          "'include_callback' function must return a yara rules as an ascii "
+          "or unicode string");
     }
-    cstring_result = NULL;
   }
+
   Py_XDECREF(result);
   PyGILState_Release(gil_state);
 
@@ -1789,12 +1791,12 @@ const char* yara_include_callback(
 }
 
 void yara_include_free(
-  const char* result_ptr,
-  void* user_data)
+    const char* result_ptr,
+    void* user_data)
 {
-  if(result_ptr != NULL)
+  if (result_ptr != NULL)
   {
-    free((void*)result_ptr);
+    free((void*) result_ptr);
   }
 }
 
@@ -1951,12 +1953,15 @@ static PyObject* yara_compile(
     else if (file != NULL)
     {
       fd = dup(PyObject_AsFileDescriptor(file));
-      if (fd != -1) {
+
+      if (fd != -1)
+      {
         fh = fdopen(fd, "r");
         error = yr_compiler_add_file(compiler, fh, NULL, NULL);
         fclose(fh);
       }
-      else {
+      else
+      {
         result = PyErr_Format(
             PyExc_TypeError,
             "'file' is not a file object");

--- a/yara-python.c
+++ b/yara-python.c
@@ -1770,8 +1770,8 @@ const char* yara_include_callback(
 
   Py_DECREF(callback);
   Py_DECREF(py_incl_name);
-  Py_XDECREF(py_calling_fn);
-  Py_XDECREF(py_calling_ns);
+  Py_DECREF(py_calling_fn);
+  Py_DECREF(py_calling_ns);
 
   const char* cstring_result = NULL;
   if (result != NULL && result != Py_None && PY_STRING_CHECK(result))


### PR DESCRIPTION
Please review my latest changes. I'm intrigued about the usage of:

PyErr_Fetch(&type, &value, &traceback);
...
PyErr_Restore(type, value, traceback);

What's exactly your intention with that?