### PR TITLE
Run tests with PyPy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ python:
   - "3.4"
   - "3.5"
   - "3.6"
+  - "pypy"
 
 before_install:
   - sudo apt-get -qq update


### PR DESCRIPTION
Running the tests with PyPy2 5.9.0 succeeds.
Let's hope that's the case with PyPy 5.8.0 as well.