### PR TITLE
Add a new set_config function that exposes yr_set_configuration

### DIFF
--- a/yara-python.c
+++ b/yara-python.c
@@ -1812,6 +1812,49 @@ void yara_include_free(
 
 ////////////////////////////////////////////////////////////////////////////////
 
+static PyObject* yara_set_config(
+    PyObject* self,
+    PyObject* args,
+    PyObject* keywords)
+{
+
+  /*
+   * It is recommended that this be kept up to date with the config
+   * options present in yara/libyara.c yr_set_configuration(...) - ck
+   */
+  static char *kwlist[] = {
+    "stack_size", "max_strings_per_rule", NULL};
+
+  unsigned int stack_size = 0;
+  unsigned int max_strings_per_rule = 0;
+
+  int error = 0;
+
+  if (PyArg_ParseTupleAndKeywords(
+        args,
+        keywords,
+        "|II",
+        kwlist,
+        &stack_size,
+        &max_strings_per_rule))
+  {
+    if(stack_size != 0) {
+      if((error = yr_set_configuration(YR_CONFIG_STACK_SIZE,
+				       &stack_size)) != ERROR_SUCCESS) {
+        return handle_error(error, NULL);
+      }
+    }
+    if(max_strings_per_rule != 0) {
+      if((error = yr_set_configuration(YR_CONFIG_MAX_STRINGS_PER_RULE,
+				       &max_strings_per_rule)) != ERROR_SUCCESS) {
+        return handle_error(error, NULL);
+      }
+    }
+  }
+
+  return Py_BuildValue("");
+}
+
 static PyObject* yara_compile(
     PyObject* self,
     PyObject* args,
@@ -2240,6 +2283,12 @@ static PyMethodDef yara_methods[] = {
     (PyCFunction) yara_load,
     METH_VARARGS | METH_KEYWORDS,
     "Loads a previously saved YARA rules file and returns an instance of class Rules"
+  },
+  {
+    "set_config",
+    (PyCFunction) yara_set_config,
+    METH_VARARGS | METH_KEYWORDS,
+    "Set a yara configuration variable (stack_size or max_strings_per_rule)"
   },
   { NULL, NULL }
 };


### PR DESCRIPTION
This Python function takes two optional kwargs: stack_size,
max_strings_per_rule. These each are unsigned int types and will be used
to update the YR_CONFIG_STACK_SIZE and YR_CONFIG_MAX_STRINGS_PER_RULE
configuration options in the matching engine, respectively. We found a
case preventing moving from cmdline yara to python-yara due to the lack
of control over these options in the Python module. This fixes that. I
suppose, at some point, it might be worthwhile to also implement a
get_config entrypoint as well.