### PR TITLE
Provide duplicate meta keys as list instead of just the last seen value

### DIFF
--- a/yara-python.c
+++ b/yara-python.c
@@ -718,7 +718,26 @@ int yara_callback(
     else
       object = PY_STRING(meta->string);
 
-    PyDict_SetItemString(meta_list, meta->identifier, object);
+    PyObject* existing_item = PyDict_GetItemString(meta_list, meta->identifier);
+    // There is already meta with this key
+    if (existing_item)
+    {
+      // The value is list so just append object
+      if (PyList_Check(existing_item))
+        PyList_Append(existing_item, object);
+      // The value is not list so create it and replace the original value in dict
+      else
+      {
+        PyObject* meta_sublist = PyList_New(0);
+        PyList_Append(meta_sublist, existing_item);
+        PyList_Append(meta_sublist, object);
+        PyDict_SetItemString(meta_list, meta->identifier, meta_sublist);
+        Py_DECREF(meta_sublist);
+      }
+    }
+    else
+      PyDict_SetItemString(meta_list, meta->identifier, object);
+
     Py_DECREF(object);
   }
 


### PR DESCRIPTION
When I run regular `yara` tool with `-m` flag to print meta information I can get all meta keys even if there are duplicates. Take this YARA file:

```
rule dummy {
	meta:
		key = "a"
		key = "b"
		key = "c"
		another_key = "d"
	condition:
		true
}
```

Here is an example of how I can obtain all of them:
```
$ yara -m /tmp/test.yar /tmp/test.yar 
dummy [key="a",key="b",key="c",another_key="d"] /tmp/test.yar
```

However, there is now way how to obtain all of them through Python API. I only get the value of the key which is mentioned as last in the file because ordinary `dict` is used. My change alters this behavior and allows you to obtain all the values. Simply, if there are any duplicates, it starts putting the values in the `list`.

Before my change:
```
$ python
>>> import yara
>>> r = yara.compile('/tmp/test.yar')
>>> m = r.match(data='abc')
>>> print(m[0].meta)
{'key': 'c', 'another_key': 'd'}
```

After my change:
```
$ python
>>> import yara
>>> r = yara.compile('/tmp/test.yar')
>>> m = r.match(data='abc')
>>> print(m[0].meta)
{'key': ['a', 'b', 'c'], 'another_key': 'd'}
```

Note: I am not that familiar with Python C API so I am not sure whether I put `Py_DECREF` wherever it's necessary.