### PR TITLE
Fixed integer conversion

### DIFF
--- a/yara-python.c
+++ b/yara-python.c
@@ -424,7 +424,7 @@ PyObject* convert_object_to_python(
   {
     case OBJECT_TYPE_INTEGER:
       if (object->value.i != UNDEFINED)
-        result = Py_BuildValue("i", object->value.i);
+        result = Py_BuildValue("l", object->value.i);
       break;
 
     case OBJECT_TYPE_STRING:


### PR DESCRIPTION
The integer value in YR_OBJECT is defined as int_64, and should be converted into a long ("l") to avoid an overflow.