### PR TITLE
Add rule, rules, match as module object

### DIFF
--- a/yara-python.c
+++ b/yara-python.c
@@ -2372,6 +2372,10 @@ MOD_INIT(yara)
   if (PyType_Ready(&Match_Type) < 0)
     return MOD_ERROR_VAL;
 
+  PyModule_AddObject(m, "Rule", &Rule_Type);
+  PyModule_AddObject(m, "Rules", &Rules_Type);
+  PyModule_AddObject(m, "Match", &Match_Type);
+
   PyModule_AddObject(m, "Error", YaraError);
   PyModule_AddObject(m, "SyntaxError", YaraSyntaxError);
   PyModule_AddObject(m, "TimeoutError", YaraTimeoutError);


### PR DESCRIPTION
This adds `Rule`, `Rules`, and `Match` types to the yara module.

This allows you to import them and use them as type hints:

```python
from yara import Rule

def foo(rule: Rule):
    pass
```