### PR TITLE
Appveyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -61,13 +61,13 @@ environment:
       VS: "Visual Studio 14 2015 Win64"
 
     - PYTHON: "C:\\Python38"
-      PYTHON_VERSION: "3.8.x"
+      PYTHON_VERSION: "3.8.x" # currently 3.8.0
       PYTHON_ARCH: "32"
       OPENSSL_LIB: "openssl-1.1.0e-vs2015"
-      VS: "Visual Studio 14 2015 Win64"
+      VS: "Visual Studio 14 2015"
 
     - PYTHON: "C:\\Python38-x64"
-      PYTHON_VERSION: "3.8.x"
+      PYTHON_VERSION: "3.8.x" # currently 3.8.0
       PYTHON_ARCH: "64"
       OPENSSL_LIB: "openssl-1.1.0e-vs2015"
       VS: "Visual Studio 14 2015 Win64"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -24,30 +24,6 @@ environment:
       OPENSSL_LIB: "openssl-1.1.0e-vs2008"
       VS: "Visual Studio 9 2008 Win64"
 
-    - PYTHON: "C:\\Python33"
-      PYTHON_VERSION: "3.3.x" # currently 3.3.5
-      PYTHON_ARCH: "32"
-      OPENSSL_LIB: "openssl-1.1.0e-vs2010"
-      VS: "Visual Studio 10 2010"
-
-    - PYTHON: "C:\\Python33-x64"
-      PYTHON_VERSION: "3.3.x" # currently 3.3.5
-      PYTHON_ARCH: "64"
-      OPENSSL_LIB: "openssl-1.1.0e-vs2010"
-      VS: "Visual Studio 10 2010 Win64"
-
-    - PYTHON: "C:\\Python34"
-      PYTHON_VERSION: "3.4.x" # currently 3.4.4
-      PYTHON_ARCH: "32"
-      OPENSSL_LIB: "openssl-1.1.0e-vs2010"
-      VS: "Visual Studio 10 2010"
-
-    - PYTHON: "C:\\Python34-x64"
-      PYTHON_VERSION: "3.4.x" # currently 3.4.4
-      PYTHON_ARCH: "64"
-      OPENSSL_LIB: "openssl-1.1.0e-vs2010"
-      VS: "Visual Studio 10 2010 Win64"
-
     - PYTHON: "C:\\Python35"
       PYTHON_VERSION: "3.5.x" # currently 3.5.4
       PYTHON_ARCH: "32"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -84,6 +84,18 @@ environment:
       OPENSSL_LIB: "openssl-1.1.0e-vs2015"
       VS: "Visual Studio 14 2015 Win64"
 
+    - PYTHON: "C:\\Python38"
+      PYTHON_VERSION: "3.8.x"
+      PYTHON_ARCH: "32"
+      OPENSSL_LIB: "openssl-1.1.0e-vs2015"
+      VS: "Visual Studio 14 2015 Win64"
+
+    - PYTHON: "C:\\Python38-x64"
+      PYTHON_VERSION: "3.8.x"
+      PYTHON_ARCH: "64"
+      OPENSSL_LIB: "openssl-1.1.0e-vs2015"
+      VS: "Visual Studio 14 2015 Win64"
+
 install:
   # If there is a newer build queued for the same PR, cancel this one.
   # The AppVeyor 'rollout builds' option is supposed to serve the same

--- a/setup.py
+++ b/setup.py
@@ -184,6 +184,7 @@ class BuildExtCommand(build_ext):
     if building_for_linux:
       module.define_macros.append(('USE_LINUX_PROC', '1'))
     elif building_for_windows:
+      module.extra_compile_args.append('/TP')
       module.define_macros.append(('USE_WINDOWS_PROC', '1'))
       module.define_macros.append(('_CRT_SECURE_NO_WARNINGS', '1'))
       module.libraries.append('kernel32')

--- a/setup.py
+++ b/setup.py
@@ -184,7 +184,6 @@ class BuildExtCommand(build_ext):
     if building_for_linux:
       module.define_macros.append(('USE_LINUX_PROC', '1'))
     elif building_for_windows:
-      module.extra_compile_args.append('/TP')
       module.define_macros.append(('USE_WINDOWS_PROC', '1'))
       module.define_macros.append(('_CRT_SECURE_NO_WARNINGS', '1'))
       module.libraries.append('kernel32')


### PR DESCRIPTION
Update libyara. Add Python 3.8 to the Appveyor's build matrix, remove Python 3.3 and 3.4.