### PR TITLE
Fix build in Appveyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -145,6 +145,7 @@ build_script:
 
 after_build:
   - "%CMD_IN_ENV% python setup.py install"
+  - "%CMD_IN_ENV% python -v tests.py"
 
 # test_script:
   # Run the project tests

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -139,17 +139,13 @@ build_script:
   # Build the compiled extension
   - "%CMD_IN_ENV% python setup.py build_ext --enable-cuckoo --enable-dotnet
     -L../jansson-%JANSSON_VERSION%/build/lib/Release;../%OPENSSL_LIB%/%OPENSSL_LIB_DIR%
-    -I../jansson-%JANSSON_VERSION%/build/include;../%OPENSSL_LIB%/include
-    -DHASH_MODULE,HAVE_LIBCRYPTO
-    -llibcryptoMT"
+    -I../jansson-%JANSSON_VERSION%/build/include;../%OPENSSL_LIB%/include"
 
 after_build:
   - "%CMD_IN_ENV% python setup.py install"
-  - "%CMD_IN_ENV% python -v tests.py"
 
-# test_script:
-  # Run the project tests
-#  - "%CMD_IN_ENV% python -v tests.py"
+test_script:
+  - "%CMD_IN_ENV% python tests.py"
 
 after_test:
   # If tests are successful, create binary packages for the project.

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,49 +15,49 @@ environment:
     - PYTHON: "C:\\Python35"
       PYTHON_VERSION: "3.5.x" # currently 3.5.4
       PYTHON_ARCH: "32"
-      OPENSSL_LIB: "openssl-1.1.0e-vs2015"
+      OPENSSL_LIB: "https://ci.appveyor.com/api/buildjobs/fakubeldw67e9pmg/artifacts/YARA.OpenSSL.x86.1.1.1.nupkg"
       VS: "Visual Studio 14 2015"
 
     - PYTHON: "C:\\Python35-x64"
       PYTHON_VERSION: "3.5.x" # currently 3.5.4
       PYTHON_ARCH: "64"
-      OPENSSL_LIB: "openssl-1.1.0e-vs2015"
+      OPENSSL_LIB: "https://ci.appveyor.com/api/buildjobs/q63539qt9yqaqspo/artifacts/YARA.OpenSSL.x64.1.1.1.nupkg"
       VS: "Visual Studio 14 2015 Win64"
 
     - PYTHON: "C:\\Python36"
       PYTHON_VERSION: "3.6.x" # currently 3.6.8
       PYTHON_ARCH: "32"
-      OPENSSL_LIB: "openssl-1.1.0e-vs2015"
+      OPENSSL_LIB: "https://ci.appveyor.com/api/buildjobs/fakubeldw67e9pmg/artifacts/YARA.OpenSSL.x86.1.1.1.nupkg"
       VS: "Visual Studio 14 2015"
 
     - PYTHON: "C:\\Python36-x64"
       PYTHON_VERSION: "3.6.x" # currently 3.6.8
       PYTHON_ARCH: "64"
-      OPENSSL_LIB: "openssl-1.1.0e-vs2015"
+      OPENSSL_LIB: "https://ci.appveyor.com/api/buildjobs/q63539qt9yqaqspo/artifacts/YARA.OpenSSL.x64.1.1.1.nupkg"
       VS: "Visual Studio 14 2015 Win64"
 
     - PYTHON: "C:\\Python37"
       PYTHON_VERSION: "3.7.x" # currently 3.7.0
       PYTHON_ARCH: "32"
-      OPENSSL_LIB: "openssl-1.1.0e-vs2015"
+      OPENSSL_LIB: "https://ci.appveyor.com/api/buildjobs/fakubeldw67e9pmg/artifacts/YARA.OpenSSL.x86.1.1.1.nupkg"
       VS: "Visual Studio 14 2015"
 
     - PYTHON: "C:\\Python37-x64"
       PYTHON_VERSION: "3.7.x" # currently 3.7.0
       PYTHON_ARCH: "64"
-      OPENSSL_LIB: "openssl-1.1.0e-vs2015"
+      OPENSSL_LIB: "https://ci.appveyor.com/api/buildjobs/q63539qt9yqaqspo/artifacts/YARA.OpenSSL.x64.1.1.1.nupkg"
       VS: "Visual Studio 14 2015 Win64"
 
     - PYTHON: "C:\\Python38"
       PYTHON_VERSION: "3.8.x" # currently 3.8.0
       PYTHON_ARCH: "32"
-      OPENSSL_LIB: "openssl-1.1.0e-vs2015"
+      OPENSSL_LIB: "https://ci.appveyor.com/api/buildjobs/fakubeldw67e9pmg/artifacts/YARA.OpenSSL.x86.1.1.1.nupkg"
       VS: "Visual Studio 14 2015"
 
     - PYTHON: "C:\\Python38-x64"
       PYTHON_VERSION: "3.8.x" # currently 3.8.0
       PYTHON_ARCH: "64"
-      OPENSSL_LIB: "openssl-1.1.0e-vs2015"
+      OPENSSL_LIB: "https://ci.appveyor.com/api/buildjobs/q63539qt9yqaqspo/artifacts/YARA.OpenSSL.x64.1.1.1.nupkg"
       VS: "Visual Studio 14 2015 Win64"
 
 install:
@@ -102,24 +102,13 @@ install:
   # latest version of wheel.
   - "%CMD_IN_ENV% pip install wheel==0.29.0"
 
+  # Downlad precompiled OpenSSL library.
   - cd ..
-  - ps: Invoke-WebRequest "https://www.npcglib.org/~stathis/downloads/$env:OPENSSL_LIB.7z" -OutFile "openssl.7z"
+  - ps: Invoke-WebRequest "$env:OPENSSL_LIB" -OutFile "openssl.7z"
   - 7z x openssl.7z
   - cd yara-python
 
-  - ps: >-
-      If ($env:PYTHON_ARCH -Match "32") {
-        $env:OPENSSL_LIB_DIR="lib"
-      } Else {
-        $env:OPENSSL_LIB_DIR="lib64"
-      }
-
-  # This is workaround for solving an issue caused by CMake not finding an
-  # appropriate compilet for Visual Studio 9 2008 Win64. This workaround was
-  # copied from: https://github.com/conda/conda-build/blob/master/appveyor.yml
-  - call appveyor\setup_x64.bat
-
-  # Download and build jansson library
+  # Download and build jansson library.
   - cd ..
   - ps: Invoke-WebRequest "https://github.com/akheron/jansson/archive/v$env:JANSSON_VERSION.zip" -OutFile "jansson.zip"
   - ps: Expand-Archive jansson.zip -DestinationPath .
@@ -138,8 +127,9 @@ clone_script:
 build_script:
   # Build the compiled extension
   - "%CMD_IN_ENV% python setup.py build_ext --enable-cuckoo --enable-dotnet
-    -L../jansson-%JANSSON_VERSION%/build/lib/Release;../%OPENSSL_LIB%/%OPENSSL_LIB_DIR%
-    -I../jansson-%JANSSON_VERSION%/build/include;../%OPENSSL_LIB%/include"
+    -L../jansson-%JANSSON_VERSION%/build/lib/Release;../openssl/lib
+    -I../jansson-%JANSSON_VERSION%/build/include;../openssl/include
+    -llibcrypto"
 
 after_build:
   - "%CMD_IN_ENV% python setup.py install"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -146,9 +146,9 @@ build_script:
 after_build:
   - "%CMD_IN_ENV% python setup.py install"
 
-test_script:
+# test_script:
   # Run the project tests
-  - "%CMD_IN_ENV% python -v tests.py"
+#  - "%CMD_IN_ENV% python -v tests.py"
 
 after_test:
   # If tests are successful, create binary packages for the project.

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -102,14 +102,14 @@ install:
   # latest version of wheel.
   - "%CMD_IN_ENV% pip install wheel==0.29.0"
 
-  # Download precompiled OpenSSL library.
+  # We are in projects/yara-python, lets go out to projects.
   - cd ..
+
+  # Download precompiled OpenSSL library.
   - ps: Invoke-WebRequest "$env:OPENSSL_LIB" -OutFile "openssl.zip"
   - ps: Expand-Archive openssl.zip -DestinationPath openssl
-  - cd yara-python
 
   # Download and build jansson library.
-  - cd ..
   - ps: Invoke-WebRequest "https://github.com/akheron/jansson/archive/v$env:JANSSON_VERSION.zip" -OutFile "jansson.zip"
   - ps: Expand-Archive jansson.zip -DestinationPath .
   - cd jansson-%JANSSON_VERSION%
@@ -117,6 +117,9 @@ install:
   - cd build
   - cmake -DJANSSON_BUILD_DOCS=OFF -DJANSSON_WITHOUT_TESTS=ON -G "%VS%" ..
   - cmake --build . --config Release
+
+  # We are in projects/jansson-%JANSSON_VERSION%/build, lets move to
+  # projects/yara-python
   - cd ../../yara-python
 
 
@@ -163,5 +166,5 @@ deploy:
 #
 
 # Uncomment these lines for enabling Remote Desktop for debugging purposes.
-on_finish:
-  - ps: $blockRdp = $true; iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))
+#on_finish:
+#  - ps: $blockRdp = $true; iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -148,7 +148,7 @@ after_build:
 
 test_script:
   # Run the project tests
-  - "%CMD_IN_ENV% python tests.py"
+  - "%CMD_IN_ENV% python -v tests.py"
 
 after_test:
   # If tests are successful, create binary packages for the project.

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -102,10 +102,10 @@ install:
   # latest version of wheel.
   - "%CMD_IN_ENV% pip install wheel==0.29.0"
 
-  # Downlad precompiled OpenSSL library.
+  # Download precompiled OpenSSL library.
   - cd ..
   - ps: Invoke-WebRequest "$env:OPENSSL_LIB" -OutFile "openssl.7z"
-  - 7z x openssl.7z
+  - 7z x -oopenssl openssl.7z
   - cd yara-python
 
   # Download and build jansson library.

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -104,8 +104,8 @@ install:
 
   # Download precompiled OpenSSL library.
   - cd ..
-  - ps: Invoke-WebRequest "$env:OPENSSL_LIB" -OutFile "openssl.7z"
-  - 7z x -oopenssl openssl.7z
+  - ps: Invoke-WebRequest "$env:OPENSSL_LIB" -OutFile "openssl.zip"
+  - ps: Expand-Archive openssl.zip -DestinationPath openssl
   - cd yara-python
 
   # Download and build jansson library.
@@ -129,6 +129,7 @@ build_script:
   - "%CMD_IN_ENV% python setup.py build_ext --enable-cuckoo --enable-dotnet
     -L../jansson-%JANSSON_VERSION%/build/lib/Release;../openssl/lib
     -I../jansson-%JANSSON_VERSION%/build/include;../openssl/include
+    -DHASH_MODULE,HAVE_LIBCRYPTO
     -llibcrypto"
 
 after_build:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -175,5 +175,5 @@ deploy:
 #
 
 # Uncomment these lines for enabling Remote Desktop for debugging purposes.
- on_finish:
+on_finish:
   - ps: $blockRdp = $true; iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,18 +12,6 @@ environment:
     # a later point release.
     # See: http://www.appveyor.com/docs/installed-software#python
 
-    - PYTHON: "C:\\Python27"
-      PYTHON_VERSION: "2.7.x" # currently 2.7.16
-      PYTHON_ARCH: "32"
-      OPENSSL_LIB: "openssl-1.1.0e-vs2008"
-      VS: "Visual Studio 9 2008"
-
-    - PYTHON: "C:\\Python27-x64"
-      PYTHON_VERSION: "2.7.x" # currently 2.7.16
-      PYTHON_ARCH: "64"
-      OPENSSL_LIB: "openssl-1.1.0e-vs2008"
-      VS: "Visual Studio 9 2008 Win64"
-
     - PYTHON: "C:\\Python35"
       PYTHON_VERSION: "3.5.x" # currently 3.5.4
       PYTHON_ARCH: "32"
@@ -187,5 +175,5 @@ deploy:
 #
 
 # Uncomment these lines for enabling Remote Desktop for debugging purposes.
-# on_finish:
-#   - ps: $blockRdp = $true; iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))
+ on_finish:
+  - ps: $blockRdp = $true; iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))

--- a/setup.py
+++ b/setup.py
@@ -221,7 +221,7 @@ class BuildExtCommand(build_ext):
       module.define_macros.append(('HAVE_STRLCAT', '1'))
 
     if self.enable_profiling:
-      module.define_macros.append(('PROFILING_ENABLED', '1'))
+      module.define_macros.append(('YR_PROFILING_ENABLED', '1'))
 
     if self.dynamic_linking:
       module.libraries.append('yara')
@@ -315,7 +315,7 @@ with open('README.rst', 'r', 'utf-8') as f:
 
 setup(
     name='yara-python',
-    version='3.11.0',
+    version='4.0.0',
     description='Python interface for YARA',
     long_description=readme,
     license='Apache 2.0',


### PR DESCRIPTION
* The precompiled OpenSSL is now extracted from the NuGet package generated by https://ci.appveyor.com/project/plusvic/openssl.

* OpenSSL was upgraded to version 1.1.1.