### PR TITLE
Remove python2 support.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,6 +31,10 @@ import shutil
 import subprocess
 
 
+if sys.version_info < (3,2):
+  sys.exit('Python 3.2 or newer is required')
+
+
 OPTIONS = [
    ('dynamic-linking', None, 'link dynamically against libyara'),
    ('enable-cuckoo', None, 'enable "cuckoo" module'),
@@ -328,6 +332,7 @@ setup(
         'Operating System :: OS Independent',
         'Development Status :: 5 - Production/Stable',
     ],
+    python_requires='>=3',
     zip_safe=False,
     cmdclass={
         'build': BuildCommand,

--- a/tests.py
+++ b/tests.py
@@ -20,11 +20,7 @@ import os
 import sys
 import unittest
 import yara
-# Python 2/3
-try:
-    import StringIO
-except:
-    import io
+import io
 
 PE32_FILE = binascii.unhexlify('\
 4d5a000000000000000000000000000000000000000000000000000000000000\
@@ -939,11 +935,7 @@ class TestYara(unittest.TestCase):
 
     def testStringIO(self):
 
-        # Python 2/3
-        try:
-            stream = StringIO.StringIO()
-        except:
-            stream = io.BytesIO()
+        stream = io.BytesIO()
 
         r1 = yara.compile(source='rule test { condition: true }')
         r1.save(file=stream)

--- a/tests.py
+++ b/tests.py
@@ -300,10 +300,7 @@ class TestYara(unittest.TestCase):
           if expected_result == SUCCEED:
             self.assertTrue(matches)
             _, _, matching_string = matches[0].strings[0]
-            if sys.version_info[0] >= 3:
-              self.assertTrue(matching_string == bytes(test[3], 'utf-8'))
-            else:
-              self.assertTrue(matching_string == test[3])
+            self.assertTrue(matching_string == bytes(test[3], 'utf-8'))
           else:
             self.assertFalse(matches)
 
@@ -551,10 +548,7 @@ class TestYara(unittest.TestCase):
         rules = yara.compile(source='rule test { strings: $a = { 61 [0-3] (62|63) } condition: $a }')
         matches = rules.match(data='abbb')
 
-        if sys.version_info[0] >= 3:
-          self.assertTrue(matches[0].strings == [(0, '$a', bytes('ab', 'utf-8'))])
-        else:
-          self.assertTrue(matches[0].strings == [(0, '$a', 'ab')])
+        self.assertTrue(matches[0].strings == [(0, '$a', bytes('ab', 'utf-8'))])
 
     def testCount(self):
 
@@ -813,14 +807,9 @@ class TestYara(unittest.TestCase):
         r = yara.compile(source='rule test { condition: ext_str matches /ssi$/ }', externals={'ext_str': 'mississippi'})
         self.assertFalse(r.match(data='dummy'))
 
-        if sys.version_info[0] >= 3:
-            self.assertTrue(yara.compile(
-                source="rule test { condition: true}",
-                externals={'foo': u'\u6765\u6613\u7f51\u7edc\u79d1' }))
-        else:
-            self.assertRaises(UnicodeEncodeError, yara.compile,
-                source="rule test { condition: true}",
-                externals={'foo': u'\u6765\u6613\u7f51\u7edc\u79d1' })
+        self.assertTrue(yara.compile(
+            source="rule test { condition: true}",
+            externals={'foo': u'\u6765\u6613\u7f51\u7edc\u79d1' }))
 
     def testCallbackAll(self):
         global rule_data
@@ -888,11 +877,10 @@ class TestYara(unittest.TestCase):
 
         self.assertTrue(len(m) == 2)
 
-        if sys.version_info[0] < 3:
-          self.assertTrue(m[0] < m[1])
-          self.assertTrue(m[0] != m[1])
-          self.assertFalse(m[0] > m[1])
-          self.assertFalse(m[0] == m[1])
+        self.assertTrue(m[0] < m[1])
+        self.assertTrue(m[0] != m[1])
+        self.assertFalse(m[0] > m[1])
+        self.assertFalse(m[0] == m[1])
 
     def testComments(self):
 
@@ -979,12 +967,8 @@ class TestYara(unittest.TestCase):
 
         r1.match(data='', modules_callback=callback)
 
-        if sys.version_info[0] >= 3:
-          self.assertTrue(data['constants']['foo'] == bytes('foo', 'utf-8'))
-          self.assertTrue(data['constants']['empty'] == bytes('', 'utf-8'))
-        else:
-          self.assertTrue(data['constants']['foo'] == 'foo')
-          self.assertTrue(data['constants']['empty'] == '')
+        self.assertTrue(data['constants']['foo'] == bytes('foo', 'utf-8'))
+        self.assertTrue(data['constants']['empty'] == bytes('', 'utf-8'))
 
         self.assertTrue(data['constants']['one'] == 1)
         self.assertTrue(data['constants']['two'] == 2)

--- a/yara-python.c
+++ b/yara-python.c
@@ -692,7 +692,7 @@ int yara_callback(
     else if (meta->type == META_TYPE_BOOLEAN)
       object = PyBool_FromLong((long) meta->integer);
     else
-      object = PyUnicode_FromString(meta->string);
+      object = PyUnicode_DecodeUTF8(meta->string, strlen(meta->string), "ignore");
 
     PyDict_SetItemString(meta_list, meta->identifier, object);
     Py_DECREF(object);
@@ -1281,7 +1281,7 @@ static PyObject* Rules_next(
       else if (meta->type == META_TYPE_BOOLEAN)
         object = PyBool_FromLong((long) meta->integer);
       else
-        object = PyUnicode_FromString(meta->string);
+        object = PyUnicode_DecodeUTF8(meta->string, strlen(meta->string), "ignore");
 
       PyDict_SetItemString(meta_list, meta->identifier, object);
       Py_DECREF(object);
@@ -1291,7 +1291,7 @@ static PyObject* Rules_next(
     rule->private = PyBool_FromLong(rules->iter_current_rule->flags & RULE_FLAGS_PRIVATE);
     rule->identifier = PyUnicode_DecodeUTF8(
         rules->iter_current_rule->identifier,
-        strlen(rules->iter_current_rule->identifier,
+        strlen(rules->iter_current_rule->identifier),
         "ignore");
     rule->tags = tag_list;
     rule->meta = meta_list;


### PR DESCRIPTION
Python2 is a dead language, we should no longer be supporting it. To that end,
this commit removes python2 support by doing the following:

If you run setup.py with a python2 interpreter, it will error out.

The pip runtime is now enforcing a required python version of 3 or higher.

Remove all preprocessor macros for supporting both python2 and python3. They are
all now python3 only.

I also removed the PYTHON_API_VERSION check since that is very old (as far as I
can tell that API version was first set in 1997).