### PR TITLE
Handle invalid unicode in metadata values.

### DIFF
--- a/tests.py
+++ b/tests.py
@@ -694,16 +694,22 @@ class TestYara(unittest.TestCase):
 
     def testMeta(self):
 
-        r = yara.compile(source=r'rule test { meta: a = "\x80" condition: true }')
-        self.assertTrue(list(r)[0].meta['a'] == '' or list(r)[0].meta['a'] == r'\x80')
+        r = yara.compile(source=r'rule test { meta: a = "foo\x80bar" condition: true }')
+        self.assertTrue(list(r)[0].meta['a'] == 'foobar')
+
+    # This test ensures that anything after the NULL character is stripped.
+    def testMetaNull(self):
+
+        r = yara.compile(source=r'rule test { meta: a = "foo\x00bar\x80" condition: true }')
+        self.assertTrue(list(r)[0].meta['a'] == 'foo')
 
     # This test is similar to testMeta but it tests the meta data generated
     # when a Match object is created.
     def testScanMeta(self):
 
-        r = yara.compile(source=r'rule test { meta: a = "\x80" condition: true }')
+        r = yara.compile(source=r'rule test { meta: a = "foo\x80bar" condition: true }')
         m = r.match(data='dummy')
-        self.assertTrue(list(m)[0].meta['a'] == '' or list(r)[0].meta['a'] == r'\x80')
+        self.assertTrue(list(m)[0].meta['a'] == 'foobar')
 
     def testFilesize(self):
 

--- a/tests.py
+++ b/tests.py
@@ -695,7 +695,7 @@ class TestYara(unittest.TestCase):
     def testMeta(self):
 
         r = yara.compile(source=r'rule test { meta: a = "\x80" condition: true }')
-        self.assertTrue(list(r)[0].meta['a'] == b'\x80')
+        self.assertTrue(list(r)[0].meta['a'] == '' or list(r)[0].meta['a'] == r'\x80')
 
     # This test is similar to testMeta but it tests the meta data generated
     # when a Match object is created.
@@ -703,7 +703,7 @@ class TestYara(unittest.TestCase):
 
         r = yara.compile(source=r'rule test { meta: a = "\x80" condition: true }')
         m = r.match(data='dummy')
-        self.assertTrue(list(m)[0].meta['a'] == b'\x80')
+        self.assertTrue(list(m)[0].meta['a'] == '' or list(r)[0].meta['a'] == r'\x80')
 
     def testFilesize(self):
 

--- a/tests.py
+++ b/tests.py
@@ -692,6 +692,19 @@ class TestYara(unittest.TestCase):
             'rule test { condition: entrypoint >= 0 }',
         ])
 
+    def testMeta(self):
+
+        r = yara.compile(source=r'rule test { meta: a = "\x80" condition: true }')
+        self.assertTrue(list(r)[0].meta['a'] == b'\x80')
+
+    # This test is similar to testMeta but it tests the meta data generated
+    # when a Match object is created.
+    def testScanMeta(self):
+
+        r = yara.compile(source=r'rule test { meta: a = "\x80" condition: true }')
+        m = r.match(data='dummy')
+        self.assertTrue(list(m)[0].meta['a'] == b'\x80')
+
     def testFilesize(self):
 
         self.assertTrueRules([

--- a/yara-python.c
+++ b/yara-python.c
@@ -46,7 +46,7 @@ typedef long Py_hash_t;
 #endif
 
 #if PY_MAJOR_VERSION >= 3
-#define PY_STRING(x) PyUnicode_FromString(x)
+#define PY_STRING(x) PyUnicode_DecodeUTF8(x, strlen(x), "ignore" )
 #define PY_STRING_TO_C(x) PyUnicode_AsUTF8(x)
 #define PY_STRING_CHECK(x) PyUnicode_Check(x)
 #else
@@ -717,22 +717,10 @@ int yara_callback(
     else if (meta->type == META_TYPE_BOOLEAN)
       object = PyBool_FromLong((long) meta->integer);
     else
-    {
       object = PY_STRING(meta->string);
-      if (object == NULL)
-      {
-        // The PY_STRING() call failed, likely because the metadata value is not
-        // valid unicode, so let's clear the error and treat it as bytes.
-        PyErr_Clear();
-        object = PyBytes_FromString(meta->string);
-      }
-    }
 
-    if (object != NULL)
-    {
-      PyDict_SetItemString(meta_list, meta->identifier, object);
-      Py_DECREF(object);
-    }
+    PyDict_SetItemString(meta_list, meta->identifier, object);
+    Py_DECREF(object);
   }
 
   yr_rule_strings_foreach(rule, string)
@@ -1332,17 +1320,10 @@ static PyObject* Rules_next(
       else if (meta->type == META_TYPE_BOOLEAN)
         object = PyBool_FromLong((long) meta->integer);
       else
-      {
         object = PY_STRING(meta->string);
-        if (object == NULL)
-          object = PyBytes_FromString(meta->string);
-      }
 
-      if (object != NULL)
-      {
-        PyDict_SetItemString(meta_list, meta->identifier, object);
-        Py_DECREF(object);
-      }
+      PyDict_SetItemString(meta_list, meta->identifier, object);
+      Py_DECREF(object);
     }
 
     rule->identifier = PY_STRING(rules->iter_current_rule->identifier);


### PR DESCRIPTION
In #135 it was brought up that you can crash the python interpreter if you have
invalid unicode in a metadata value. This is my attempt to fix that by
attempting to create a string, and if that fails falling back to a bytes object.
On the weird chance that the bytes object fails to create I added a safety check
so that we don't add a NULL ptr to the dictionary (this is how the crash was
manifesting).

It's debatable if we want to ONLY add strings as metadata, and NOT fallback to
bytes. If we don't fall back to bytes the only other option I see is to silently
drop that metadata on the floor. The tradeoff here is that now you may end up
with a string or a bytes object in your metadata dictionary, which is less than
ideal IMO.

I'm open to suggestions on this one.

Fixes #135