### PR TITLE
Allow a Py_buffer as data for Rules_match

### DIFF
--- a/tests.py
+++ b/tests.py
@@ -1050,6 +1050,13 @@ class TestYara(unittest.TestCase):
         self.assertTrue(r[0].is_global == True)
         self.assertTrue(r[1].is_private == True)
 
+    def testMatchMemoryview(self):
+
+        r = yara.compile(source='rule test { strings: $s = "test" condition: $s }')
+        data = memoryview(b"test")
+
+        self.assertTrue(r.match(data=data))
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/yara-python.c
+++ b/yara-python.c
@@ -1372,13 +1372,12 @@ static PyObject* Rules_match(
       };
 
   char* filepath = NULL;
-  Py_buffer data;
+  Py_buffer data = {0};
 
   int pid = 0;
   int timeout = 0;
   int error = ERROR_SUCCESS;
   int fast_mode = 0;
-  int has_data = 0;
 
   PyObject* externals = NULL;
   PyObject* fast = NULL;
@@ -1494,7 +1493,6 @@ static PyObject* Rules_match(
     }
     else if (data.buf != NULL)
     {
-      has_data = 1;
       callback_data.matches = PyList_New(0);
 
       Py_BEGIN_ALLOW_THREADS
@@ -1550,13 +1548,13 @@ static PyObject* Rules_match(
         {
           handle_error(error, filepath);
         }
-        else if (has_data)
-        {
-          handle_error(error, "<data>");
-        }
         else if (pid != 0)
         {
           handle_error(error, "<proc>");
+        }
+        else
+        {
+          handle_error(error, "<data>");
         }
 
         #ifdef PROFILING_ENABLED


### PR DESCRIPTION
This makes rules matching compatible with data objects `PyArg_ParseTuple` does not consider read-only (even though they might actually be), such a memoryviews. The main change is replacing the `s#` formatter with `s*` and replacing the `(pointer, length)` pair with a `Py_buffer` object accordingly. Additional care must be taken to release the `Py_buffer` on every error path.

Resolves #147.