### PR TITLE
Release GIL while compiling Yara rules

### DIFF
--- a/yara-python.c
+++ b/yara-python.c
@@ -1891,6 +1891,8 @@ void raise_exception_on_error(
     const char* message,
     void* user_data)
 {
+  PyGILState_STATE gil_state = PyGILState_Ensure();
+
   if (error_level == YARA_ERROR_LEVEL_ERROR)
   {
     if (file_name != NULL)
@@ -1925,6 +1927,8 @@ void raise_exception_on_error(
     PyList_Append(warnings, warning_msg);
     Py_DECREF(warning_msg);
   }
+
+  PyGILState_Release(gil_state);
 }
 
 

--- a/yara-python.c
+++ b/yara-python.c
@@ -2228,8 +2228,10 @@ static PyObject* yara_compile(
 
       if (fh != NULL)
       {
+        Py_BEGIN_ALLOW_THREADS
         error = yr_compiler_add_file(compiler, fh, NULL, filepath);
         fclose(fh);
+        Py_END_ALLOW_THREADS
       }
       else
       {
@@ -2238,7 +2240,9 @@ static PyObject* yara_compile(
     }
     else if (source != NULL)
     {
+      Py_BEGIN_ALLOW_THREADS
       error = yr_compiler_add_string(compiler, source, NULL);
+      Py_END_ALLOW_THREADS
     }
     else if (file != NULL)
     {
@@ -2246,9 +2250,11 @@ static PyObject* yara_compile(
 
       if (fd != -1)
       {
+        Py_BEGIN_ALLOW_THREADS
         fh = fdopen(fd, "r");
         error = yr_compiler_add_file(compiler, fh, NULL, NULL);
         fclose(fh);
+        Py_END_ALLOW_THREADS
       }
       else
       {
@@ -2268,7 +2274,9 @@ static PyObject* yara_compile(
 
           if (source != NULL && ns != NULL)
           {
+            Py_BEGIN_ALLOW_THREADS
             error = yr_compiler_add_string(compiler, source, ns);
+            Py_END_ALLOW_THREADS
 
             if (error > 0)
               break;
@@ -2305,8 +2313,10 @@ static PyObject* yara_compile(
 
             if (fh != NULL)
             {
+              Py_BEGIN_ALLOW_THREADS
               error = yr_compiler_add_file(compiler, fh, ns, filepath);
               fclose(fh);
+              Py_END_ALLOW_THREADS
 
               if (error > 0)
                 break;


### PR DESCRIPTION
This PR adds code that releases GIL while compiling Yara rules. We noticed that when we compile rules in parallel there is no speedup in comparison to sequential compilation.

The bottleneck is that GIL is not released in a function that is CPU intensive. I added the code that releases and reacquires GIL. This eliminates the bottleneck in the multithreaded environment. 

The second commit fixes the GIL locking in the callback. The callback is called in case the Yara rule is invalid.

Here is the code I used for benchmarks.

```python
"""
    Yara threaded compilation.
"""

import concurrent.futures
import time
import yara

counter = 0


def any_yara_rule():
    global counter

    counter += 1

    return f"""
        rule any_rule_{counter}
        {{
            strings:
                $text_string = "some string {counter}"
            condition:
                $text_string
        }}   
    """


def generate_ruleset(n=10_000):
    rules = []
    for i in range(n):
        rules.append(any_yara_rule())
    return '\n'.join(rules)


try:
    # Causes segfault if callback is called without GIL.
    yara.compile(source='{}', error_on_warning=True)
except yara.SyntaxError:
    pass

ruleset_as_text = generate_ruleset()
N_RULESETS = 100

# Sequential
s = time.time()
for i in range(N_RULESETS):
    res = yara.compile(source=ruleset_as_text, error_on_warning=True)

seq = time.time() - s
print('Sequential', seq)

# Parallel
s = time.time()
max_workers = 4
with concurrent.futures.ThreadPoolExecutor(max_workers=max_workers) as executor:
    futures = []
    for i in range(N_RULESETS):
        fut = executor.submit(yara.compile, source=ruleset_as_text)
        futures.append(fut)

    for fut in futures:
        fut.result()

par = time.time() - s
print('Parallel', par)
print(f'Speedup with {max_workers} workers', seq / par)

```