### PR TITLE
Add console_callback to match call.

### DIFF
--- a/tests.py
+++ b/tests.py
@@ -936,6 +936,19 @@ class TestYara(unittest.TestCase):
         r = yara.compile(source='include "foo" rule r { condition: included }', include_callback=callback)
         self.assertTrue(r.match(data='dummy'))
 
+    def testConsoleCallback(self):
+        global called
+        called = False
+
+        def callback(message):
+            global called
+            called = True
+            return yara.CALLBACK_CONTINUE
+
+        r = yara.compile(source='import "console" rule r { condition: console.log("AXSERS") }')
+        r.match(data='dummy', console_callback=callback)
+        self.assertTrue(called)
+
     def testCompare(self):
 
         r = yara.compile(sources={

--- a/yara-python.c
+++ b/yara-python.c
@@ -702,6 +702,9 @@ static int handle_console_log(
   if (data->console_callback == NULL)
   {
     // If the user does not specify a console callback we dump to stdout.
+    // If we want to support 3.2 and newer only we can use
+    // https://docs.python.org/3/c-api/sys.html?highlight=stdout#c.PySys_FormatStdout
+    // instead of this call with the limit.
     PySys_WriteStdout("%.1000s\n", (char*) message_data);
   }
   else


### PR DESCRIPTION
This provides the user with an interface to handle console.log() messages. If
not provided the log message is printed to stdout (limited to 1000 bytes based
upon https://docs.python.org/3/c-api/sys.html?highlight=stdout#c.PySys_WriteStdout).

Tested with the following (along with the updated tests):

wxs@wxs-mbp yara-python % cat test.py
import yara

r = """
import "console"

rule a { condition: console.log("Hello from Python!") }
"""

def console(message):
    print(f"Callback: {message}")

rules = yara.compile(source=r)
rules.match("/bin/ls", console_callback=console)
rules.match("/bin/ls")
wxs@wxs-mbp yara-python % PYTHONPATH=build/lib.macosx-10.14-arm64-3.8 python3 test.py
Callback: Hello from Python!
Hello from Python!
wxs@wxs-mbp yara-python %