### PR TITLE
Fix deprecation warning from setuptools

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [metadata]
-description-file = README.md
+description_file = README.md
 license_file = LICENSE
 
 [test]


### PR DESCRIPTION
This commit fixes the following deprecation warning.

```
/usr/lib/python3.9/site-packages/setuptools/dist.py:723: UserWarning: Usage of dash-separated 'description-file' will not be supported in future versions. Please use the underscore name 'description_file' instead
```