### PR TITLE
Allow metadata to contain a list of values

### DIFF
--- a/tests.py
+++ b/tests.py
@@ -752,6 +752,28 @@ class TestYara(unittest.TestCase):
         self.assertTrue(meta['b'] == 'ñ')
         self.assertTrue(meta['c'] == 'ñ')
 
+    # This test is similar to testScanMeta but it tests for displaying multiple values in the meta data generated
+    # when a Match object is created (upon request).
+    def testDuplicateMeta(self):
+        r = yara.compile(source="""
+        rule test {
+            meta:
+                a = 1
+                a = 2
+                b = 3
+            condition:
+                true
+        }
+        """)
+
+        # Default behaviour should produce a simple KV map and should use the 'latest' metadata value per field
+        meta = r.match(data="dummy")[0].meta
+        self.assertTrue(meta['a'] == 2 and meta['b'] == 3)
+
+        # `allow_duplicate_metadata` flag should reveal all metadata values per field as a list
+        meta = r.match(data="dummy", allow_duplicate_metadata=True)[0].meta
+        self.assertTrue(meta['a'] == [1, 2] and meta['b'] == [3])
+
     def testFilesize(self):
 
         self.assertTrueRules([

--- a/yara-python.c
+++ b/yara-python.c
@@ -975,8 +975,25 @@ int yara_callback(
     else
       object = PY_STRING(meta->string);
 
-    PyDict_SetItemString(meta_list, meta->identifier, object);
-    Py_DECREF(object);
+    // Check if we already have an entry under this key
+    PyObject* existing_item = PyDict_GetItemString(meta_list, meta->identifier);
+    if (existing_item){
+      // If the type is an array, append item
+      if (PyList_Check(existing_item))
+        PyList_Append(existing_item, object);
+      else{
+        //Otherwise, instantiate array and append items
+        PyObject* new_list = PyList_New(0);
+        PyList_Append(new_list, existing_item);
+        PyList_Append(new_list, object);
+        PyDict_SetItemString(meta_list, meta->identifier, new_list);
+        Py_DECREF(new_list);
+      }
+    }
+    else{
+      PyDict_SetItemString(meta_list, meta->identifier, object);
+      Py_DECREF(object);
+    }
   }
 
   yr_rule_strings_foreach(rule, string)
@@ -1580,8 +1597,25 @@ static PyObject* Rules_next(
       else
         object = PY_STRING(meta->string);
 
-      PyDict_SetItemString(meta_list, meta->identifier, object);
-      Py_DECREF(object);
+      // Check if we already have an entry under this key
+      PyObject* existing_item = PyDict_GetItemString(meta_list, meta->identifier);
+      if (existing_item){
+        // If the type is an array, append item
+        if (PyList_Check(existing_item))
+          PyList_Append(existing_item, object);
+        else{
+          //Otherwise, instantiate array and append items
+          PyObject* new_list = PyList_New(0);
+          PyList_Append(new_list, existing_item);
+          PyList_Append(new_list, object);
+          PyDict_SetItemString(meta_list, meta->identifier, new_list);
+          Py_DECREF(new_list);
+        }
+      }
+      else{
+        PyDict_SetItemString(meta_list, meta->identifier, object);
+        Py_DECREF(object);
+      }
     }
 
     rule->global = PyBool_FromLong(rules->iter_current_rule->flags & RULE_FLAGS_GLOBAL);


### PR DESCRIPTION
Derivation of: https://github.com/VirusTotal/yara-python/pull/74 😍

This allows the `Match.meta` values to becomes lists if there are rule meta with the same name but different values. This is also to bring output from the Python library more inline with the output from the commandline.

ie. Suppose there's a match given for the following rule:
```
rule myRule :
{
	meta:
              ...
		malware = "BAD THING"
		malware = "REALLY BAD THING"
         ...
}

```

The corresponding values in `Match.meta['malware']` will be:
`["BAD THING", "REALLY BAD THING"]` instead of just `"REALLY BAD THING"`

