### PR TITLE
Add modules list to yara object.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -371,4 +371,5 @@ setup(
     ext_modules=[Extension(
         name='yara',
         include_dirs=['yara/libyara/include', 'yara/libyara/', '.'],
+        define_macros=[('BUCKETS_128', 1), ('CHECKSUM_1B', 1)],
         sources=['yara-python.c'])])

--- a/yara-python.c
+++ b/yara-python.c
@@ -2762,6 +2762,29 @@ MOD_INIT(yara)
     return MOD_ERROR_VAL;
   }
 
+  PyObject* module_names_list = PyList_New(0);
+  if (module_names_list == NULL)
+  {
+    PyErr_SetString(YaraError, "module list error");
+    return MOD_ERROR_VAL;
+  }
+
+  for (YR_MODULE* module = yr_modules_get_table(); module->name != NULL; module++)
+  {
+    PyObject* module_name = PY_STRING(module->name);
+    if (module_name == NULL)
+    {
+      PyErr_SetString(YaraError, "module name error");
+      return MOD_ERROR_VAL;
+    }
+    if (PyList_Append(module_names_list, module_name) < 0)
+    {
+      PyErr_SetString(YaraError, "module name error");
+      return MOD_ERROR_VAL;
+    }
+  }
+  PyModule_AddObject(m, "modules", module_names_list);
+
   Py_AtExit(finalize);
 
   return MOD_SUCCESS_VAL(m);


### PR DESCRIPTION
Add support for getting the list of available modules. It is available just by accessing the yara.modules attribute, which contains a list of available modules.

>>> print('\n'.join(yara.modules))
tests
pe
elf
math
time
console
>>>

Note: This commit also brings in the necessary defines to build the authenticode parser, which is also done in the xor_value branch. Also, this commit updates the yara submodule which will likely overwrite the changes done in the xor_value so I recommend updating the submodule after both are merged.