### PR TITLE
Fix Appveyor build

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -140,8 +140,8 @@ clone_script:
 build_script:
   # Build the compiled extension
   - "%CMD_IN_ENV% python setup.py build_ext --enable-cuckoo --enable-openssl
-    -L../jansson-%JANSSON_VERSION%/build/lib/Release;../openssl/lib
-    -I../jansson-%JANSSON_VERSION%/build/include;../openssl/include
+    -L../jansson-%JANSSON_VERSION%/build/lib/Release
+    -I../jansson-%JANSSON_VERSION%/build/include
     -llibcrypto"
 
 after_build:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -139,11 +139,10 @@ clone_script:
 
 build_script:
   # Build the compiled extension
-  - "%CMD_IN_ENV% python setup.py build_ext --enable-cuckoo
+  - "%CMD_IN_ENV% python setup.py build_ext --enable-cuckoo --enable-openssl
     -L../jansson-%JANSSON_VERSION%/build/lib/Release;../openssl/lib
     -I../jansson-%JANSSON_VERSION%/build/include;../openssl/include
-    -DHASH_MODULE,HAVE_LIBCRYPTO,BUCKETS_128,CHECKSUM_1B
-    -llibcrypto"
+    -DBUCKETS_128,CHECKSUM_1B -llibcrypto"
 
 after_build:
   - "%CMD_IN_ENV% python setup.py install"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -142,7 +142,7 @@ build_script:
   - "%CMD_IN_ENV% python setup.py build_ext --enable-cuckoo --enable-openssl
     -L../jansson-%JANSSON_VERSION%/build/lib/Release;../openssl/lib
     -I../jansson-%JANSSON_VERSION%/build/include;../openssl/include
-    -DBUCKETS_128,CHECKSUM_1B -llibcrypto"
+    -llibcrypto"
 
 after_build:
   - "%CMD_IN_ENV% python setup.py install"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -140,8 +140,8 @@ clone_script:
 build_script:
   # Build the compiled extension
   - "%CMD_IN_ENV% python setup.py build_ext --enable-cuckoo --enable-openssl
-    -L../jansson-%JANSSON_VERSION%/build/lib/Release
-    -I../jansson-%JANSSON_VERSION%/build/include
+    -L../jansson-%JANSSON_VERSION%/build/lib/Release;../openssl/lib
+    -I../jansson-%JANSSON_VERSION%/build/include;../openssl/include
     -llibcrypto"
 
 after_build:

--- a/setup.py
+++ b/setup.py
@@ -290,7 +290,7 @@ class BuildExtCommand(build_ext):
                        include_dirs=module.include_dirs + openssl_include_dirs,
                        libraries=module.libraries + openssl_libraries + ['dl', 'pthread', 'z'],
                        library_dirs=module.library_dirs + openssl_library_dirs)
-          ):
+          or self.enable_openssl):
         module.define_macros.append(('HASH_MODULE', '1'))
         module.define_macros.append(('HAVE_LIBCRYPTO', '1'))
         module.libraries.extend(openssl_libraries)
@@ -301,15 +301,7 @@ class BuildExtCommand(build_ext):
         # hashing functions.
         module.define_macros.append(('HASH_MODULE', '1'))
         module.define_macros.append(('HAVE_WINCRYPT_H', '1'))
-        # However authenticode-parser must be excluded because it relies on
-        # OpenSSL.
-        if self.enable_openssl:
-          module.define_macros.append(('HAVE_LIBCRYPTO', '1'))
-        else: 
-          exclusions.append('yara/libyara/modules/pe/authenticode-parser')
       else:
-        # OpenSSL is not available, exclude the hash module and authenticode
-        # parser.
         exclusions.append('yara/libyara/modules/hash/hash.c')
         exclusions.append('yara/libyara/modules/pe/authenticode-parser')
 

--- a/setup.py
+++ b/setup.py
@@ -301,7 +301,10 @@ class BuildExtCommand(build_ext):
         # hashing functions.
         module.define_macros.append(('HASH_MODULE', '1'))
         module.define_macros.append(('HAVE_WINCRYPT_H', '1'))
+        # The authenticode parser depends on OpenSSL and must be excluded.
+        exclusions.append('yara/libyara/modules/pe/authenticode-parser')
       else:
+        # Without OpenSSL there's no hash module nor authenticode parser.
         exclusions.append('yara/libyara/modules/hash/hash.c')
         exclusions.append('yara/libyara/modules/pe/authenticode-parser')
 


### PR DESCRIPTION
`setup.py` includes a new `--enable-openssl` flag that forces the use of OpenSSL. This flag is mainly to be used in Appveyor, where the OpenSSL is installed. Users building `yara-python` in Windows with `python setup.py build` won't have features that depend on OpenSSL, but the build will be succesful.