### PR TITLE
Fix unknown escape sequence

### DIFF
--- a/tests.py
+++ b/tests.py
@@ -719,7 +719,7 @@ class TestYara(unittest.TestCase):
             'rule test { strings: $a = /[M-N]iss/ nocase condition: $a }',
             'rule test { strings: $a = /(Mi|ssi)ssippi/ nocase condition: $a }',
             r'rule test { strings: $a = /ppi\tmi/ condition: $a }',
-            'rule test { strings: $a = /ppi\.mi/ condition: $a }',
+            r'rule test { strings: $a = /ppi\.mi/ condition: $a }',
             'rule test { strings: $a = /^mississippi/ fullword condition: $a }',
             'rule test { strings: $a = /mississippi.*mississippi$/s condition: $a }',
         ], 'mississippi\tmississippi.mississippi\nmississippi')


### PR DESCRIPTION
`\.` is not an allowed escape sequence from Python 3.12 on. Seems to be a regression of #223.