### PR TITLE
Fixed install with pip, added new homebrew path

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -242,6 +242,8 @@ class BuildExtCommand(build_ext):
       module.include_dirs.append('/usr/local/include')
       module.library_dirs.append('/usr/local/lib')
       module.library_dirs.append('/usr/local/opt/openssl/lib')
+      module.include_dirs.append('/opt/homebrew/include')
+      module.library_dirs.append('/opt/homebrew/opt/openssl/lib')
     elif building_for_freebsd:
       module.define_macros.append(('_GNU_SOURCE', '1'))
       module.define_macros.append(('USE_FREEBSD_PROC', '1'))


### PR DESCRIPTION
This PR changes the setup.py and adds new paths to the configuration of the `library` and `include` folders for handling the `pip` installation on Macs with Apple Silicon.

On Apple Silicon, Homebrew uses another path (`/opt/homebrew` instead of `/usr/local`) in comparison to the Intel Mac Version (see https://docs.brew.sh/Installation).

Without this change the build would fail on this platform, like described in https://github.com/VirusTotal/yara-python/issues/239.

I verified the change manually using `pip install -e yara-python` on the (locally changed) packaged version, downloaded from the PyPi repository.