### PR TITLE
ci: add a github workflow to build and publish linux wheels

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -1,0 +1,52 @@
+name: Publish Python distribution to PyPI
+
+on: push
+
+jobs:
+  build:
+    runs-on: ubuntu-22.04
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+
+      - name: Install cibuildwheel
+        run: python3 -m pip install cibuildwheel==2.16.4
+
+      - name: Build wheels
+        run: python -m cibuildwheel --output-dir dist/
+
+      - name: Store the distribution packages
+        uses: actions/upload-artifact@v4
+        with:
+          name: python-package-distributions
+          path: dist/*.whl
+
+  publish-to-pypi:
+    needs: [build]
+    runs-on: ubuntu-latest
+
+    # Only publish to PyPI on tag pushes
+    if: startsWith(github.ref, 'refs/tags/')
+
+    environment:
+      name: pypi
+      url: https://pypi.org/p/yara-python
+    permissions:
+      id-token: write  # IMPORTANT: mandatory for trusted publishing
+
+    steps:
+      - name: Download all the dists
+        uses: actions/download-artifact@v4
+        with:
+          name: python-package-distributions
+          path: dist/
+
+      - name: Publish distribution to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
Hi :wave: 

I submit a PR to build linux wheels in CI, related to my issue https://github.com/VirusTotal/yara-python/issues/249. 

I use [pypa/cibuildwheel](https://github.com/pypa/cibuildwheel) to build linux wheels on multiple versions of Python.

This workflow :
1. Generate a zip file as artifacts, that contains several wheels:
```
yara_python-4.4.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
yara_python-4.4.0-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl
yara_python-4.4.0-cp310-cp310-musllinux_1_1_i686.whl
yara_python-4.4.0-cp310-cp310-musllinux_1_1_x86_64.whl
yara_python-4.4.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
yara_python-4.4.0-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl
yara_python-4.4.0-cp311-cp311-musllinux_1_1_i686.whl
yara_python-4.4.0-cp311-cp311-musllinux_1_1_x86_64.whl
yara_python-4.4.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
yara_python-4.4.0-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl
yara_python-4.4.0-cp312-cp312-musllinux_1_1_i686.whl
yara_python-4.4.0-cp312-cp312-musllinux_1_1_x86_64.whl
yara_python-4.4.0-cp36-cp36m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
yara_python-4.4.0-cp36-cp36m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl
yara_python-4.4.0-cp36-cp36m-musllinux_1_1_i686.whl
yara_python-4.4.0-cp36-cp36m-musllinux_1_1_x86_64.whl
yara_python-4.4.0-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
yara_python-4.4.0-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl
yara_python-4.4.0-cp37-cp37m-musllinux_1_1_i686.whl
yara_python-4.4.0-cp37-cp37m-musllinux_1_1_x86_64.whl
yara_python-4.4.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
yara_python-4.4.0-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl
yara_python-4.4.0-cp38-cp38-musllinux_1_1_i686.whl
yara_python-4.4.0-cp38-cp38-musllinux_1_1_x86_64.whl
yara_python-4.4.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
yara_python-4.4.0-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl
yara_python-4.4.0-cp39-cp39-musllinux_1_1_i686.whl
yara_python-4.4.0-cp39-cp39-musllinux_1_1_x86_64.whl
yara_python-4.4.0-pp310-pypy310_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
yara_python-4.4.0-pp310-pypy310_pp73-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl
yara_python-4.4.0-pp37-pypy37_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
yara_python-4.4.0-pp37-pypy37_pp73-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl
yara_python-4.4.0-pp38-pypy38_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
yara_python-4.4.0-pp38-pypy38_pp73-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl
yara_python-4.4.0-pp39-pypy39_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
yara_python-4.4.0-pp39-pypy39_pp73-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl
```

2. Automatically publish wheels to PyPI, on pushed tag, but required some configuration on the PyPI repo, to  configure the workflow as a trusted publisher (see [configuring-trusted-publishing](https://packaging.python.org/en/latest/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows/#configuring-trusted-publishing)).