### PR TITLE
Pass build parameters correctly, enable dex and macho modules

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - master
-    tags:
   pull_request:
   workflow_dispatch:
 
@@ -21,6 +20,7 @@ jobs:
         include:
           - os: ubuntu-22.04
             arch: x86_64
+            build-sdist: true
           - os: ubuntu-22.04
             arch: i686
           - os: ubuntu-22.04
@@ -43,7 +43,7 @@ jobs:
 
       - name: Set up QEMU
         if: runner.os == 'Linux'
-        uses: docker/setup-qemu-action@v2
+        uses: docker/setup-qemu-action@v3
         with:
           platforms: all
 
@@ -67,9 +67,8 @@ jobs:
             fi
           CIBW_BEFORE_ALL_WINDOWS: ${{ matrix.before }}
           CIBW_BUILD_FRONTEND: build
-          CIBW_CONFIG_SETTINGS: --enable-cuckoo --enable-magic --enable-dex --enable-macho --enable-openssl
           CIBW_ENVIRONMENT: ${{ matrix.env }}
-          CIBW_SKIP: cp36-*
+          CIBW_SKIP: cp36-* *-macosx_universal2:arm64
           CIBW_TEST_COMMAND: python {package}/tests.py
 
       - name: Store the distribution packages
@@ -77,6 +76,17 @@ jobs:
         with:
           name: python-package-distributions-${{ matrix.os }}-${{ matrix.arch }}
           path: dist/*.whl
+
+      - name: Build Sdist
+        if: ${{ matrix.build-sdist }}
+        run: pipx run build --sdist
+      
+      - name: Store the source distribution package
+        if: ${{ matrix.build-sdist }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: python-package-distributions-source
+          path: dist/*.tar.gz
 
   publish-to-pypi:
     needs: [build]

--- a/setup.cfg
+++ b/setup.cfg
@@ -6,8 +6,9 @@ license_file = LICENSE
 test_suite=tests
 
 [build_ext]
-enable_dex = true
-enable_macho = true
+# These modules are not stable or tested enough 
+# enable_dex = true
+# enable_macho = true
 
 # need libjansson-dev
 # enable_cuckoo = true

--- a/setup.cfg
+++ b/setup.cfg
@@ -4,3 +4,13 @@ license_file = LICENSE
 
 [test]
 test_suite=tests
+
+[build_ext]
+enable_dex = true
+enable_macho = true
+
+# need libjansson-dev
+# enable_cuckoo = true
+
+# need libmagic-dev
+# enable_magic = true


### PR DESCRIPTION
Fix for #254

According to the discussion under this [PR](https://github.com/pypa/setuptools/pull/4218#issuecomment-1956588614), build parameters should be added via the `setup.cfg` file.

Enabling modules `cuckoo` and `magic` requires the build machine to install additional libraries. To avoid major CI changes, keep them disabled.

The `openssl` part will be automatically enabled based on whether there is openssl in the build environment, so there is no need to configure and enable it.
If oepnssl is manually configured and enabled, an error will occur when building the `-macosx_universal2` wheel. Because the macos build environment cannot provide the arm version of openssl dependent libraries. Due to parameter passing issues in previous builds, the `-macosx_universal2` version of the package did not enable openssl and did not include the hash module. 

I kept the `-macosx_universal2` version of the build, but it still doesn't have openssl enabled, and it still doesn't include the hash module. This may cause confusion for arm64 macos users, so according to #253 , a build of sdist was added. This allows advanced users to use local build installations if necessary.

In addition, according to the instructions in the CI log:
https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/
 I upgraded the version of `docker/setup-qemu-action`.