### PR TITLE
fix CIBW_TEST_SKIP

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -68,7 +68,8 @@ jobs:
           CIBW_BEFORE_ALL_WINDOWS: ${{ matrix.before }}
           CIBW_BUILD_FRONTEND: build
           CIBW_ENVIRONMENT: ${{ matrix.env }}
-          CIBW_SKIP: cp36-* *-macosx_universal2:arm64
+          CIBW_SKIP: cp36-*
+          CIBW_TEST_SKIP: "*-macosx_universal2:arm64"
           CIBW_TEST_COMMAND: python {package}/tests.py
 
       - name: Store the distribution packages


### PR DESCRIPTION
Sorry, I made a stupid mistake in my last PR.

The current CI process cannot complete testing of the `Mac arm` dist, and there are related warning logs.

I wanted to skip these tests, but added the wrong parameters. Fortunately, there were no additional side effects.