### PR TITLE
fix: avoid crash on Windows when passing invalid file to compile function

### DIFF
--- a/yara-python.c
+++ b/yara-python.c
@@ -2816,12 +2816,12 @@ static PyObject* yara_compile(
     }
     else if (file != NULL)
     {
-      fd = dup(PyObject_AsFileDescriptor(file));
+      fd = PyObject_AsFileDescriptor(file);
 
       if (fd != -1)
       {
         Py_BEGIN_ALLOW_THREADS
-        fh = fdopen(fd, "r");
+        fh = fdopen(dup(fd), "r");
         error = yr_compiler_add_file(compiler, fh, NULL, NULL);
         fclose(fh);
         Py_END_ALLOW_THREADS


### PR DESCRIPTION
When providing a file to the compile function, the PyObject_AsFileDescriptor function is used, which is safe to use on any object type: if the object is not a file, -1 is returned.

However, this value was passed straight to a call to dup() without checking for its validity. This isn't much of an issue on unix where the dup call will simply fail as well and return -1, but it is very much an issue on windows where passing an invalid fd to dup will invoke the invalid parameter handler, which isn't set, so it will simply terminate the program.

In other words, passing anything but a file to the file parameter of the compile function will make the program crash on Windows.