### PR TITLE
fix: check key type in externals dict

### DIFF
--- a/yara-python.c
+++ b/yara-python.c
@@ -1522,6 +1522,13 @@ int process_compile_externals(
 
   while (PyDict_Next(externals, &pos, &key, &value))
   {
+    if (!PY_STRING_CHECK(key)) {
+      PyErr_Format(
+          PyExc_TypeError,
+          "keys of externals dict must be strings");
+
+      return ERROR_INVALID_ARGUMENT;
+    }
     identifier = PY_STRING_TO_C(key);
 
     if (PyBool_Check(value))
@@ -1592,6 +1599,13 @@ int process_match_externals(
 
   while (PyDict_Next(externals, &pos, &key, &value))
   {
+    if (!PY_STRING_CHECK(key)) {
+      PyErr_Format(
+          PyExc_TypeError,
+          "keys of externals dict must be strings");
+
+      return ERROR_INVALID_ARGUMENT;
+    }
     identifier = PY_STRING_TO_C(key);
 
     if (PyBool_Check(value))


### PR DESCRIPTION
The type of the key for the externals dict in both the compile and the match function was not checked. Providing a dict with non string keys leads to a segfault:

For example:

```py
import yara

rules = yara.compile(source="", externals={ "a": 2 })
rules.match(data="", externals={ 1: 2 })
```