### PR TITLE
Start building for Python 3.13.

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -67,6 +67,18 @@ environment:
       OPENSSL_LIB: "https://ci.appveyor.com/api/buildjobs/q63539qt9yqaqspo/artifacts/YARA.OpenSSL.x64.1.1.1.nupkg"
       VS: "Visual Studio 14 2015 Win64"
 
+    - PYTHON: "C:\\Python313"
+      PYTHON_VERSION: "3.13.2"
+      PYTHON_ARCH: "32"
+      OPENSSL_LIB: "https://ci.appveyor.com/api/buildjobs/fakubeldw67e9pmg/artifacts/YARA.OpenSSL.x86.1.1.1.nupkg"
+      VS: "Visual Studio 14 2015"
+
+    - PYTHON: "C:\\Python313-x64"
+      PYTHON_VERSION: "3.13.2"
+      PYTHON_ARCH: "64"
+      OPENSSL_LIB: "https://ci.appveyor.com/api/buildjobs/q63539qt9yqaqspo/artifacts/YARA.OpenSSL.x64.1.1.1.nupkg"
+      VS: "Visual Studio 14 2015 Win64"
+
 install:
   # If there is a newer build queued for the same PR, cancel this one.
   # The AppVeyor 'rollout builds' option is supposed to serve the same


### PR DESCRIPTION
I went through the CI process and believe this change will allow .whl files to be built on Python 3.13. Let me know if anything else is needed!