### PR TITLE
Fix issues with macOS wheels.

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -68,7 +68,7 @@ jobs:
               apk add openssl-dev
             fi
           CIBW_BEFORE_ALL_WINDOWS: ${{ matrix.before }}
-          CIBW_BUILD_FRONTEND: "build; args: --config-setting=--enable_openssl"  
+          CIBW_BUILD_FRONTEND: "build; args: --config-setting=--enable-openssl"  
           CIBW_ENVIRONMENT: ${{ matrix.env }}
           CIBW_TEST_SKIP: "*-macosx_arm64 *-macosx_x86_64"
           CIBW_TEST_COMMAND: python {package}/tests.py

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -66,12 +66,8 @@ jobs:
             elif [[ ! -z "$(which apk)" ]]; then
               apk add openssl-dev
             fi
-          CIBW_BEFORE_ALL_MACOS: |
-            ls /usr/local/opt/openssl
-            ls /opt/homebrew/include
-            ls /opt/homebrew/opt/openssl/lib
           CIBW_BEFORE_ALL_WINDOWS: ${{ matrix.before }}
-          CIBW_BUILD_FRONTEND: build
+          CIBW_BUILD_FRONTEND: "build; args: --enable-openssl"
           CIBW_ENVIRONMENT: ${{ matrix.env }}
           CIBW_TEST_SKIP: "*-macosx_universal2:arm64"
           CIBW_TEST_COMMAND: python {package}/tests.py

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -68,6 +68,7 @@ jobs:
             fi
           CIBW_BEFORE_ALL_MACOS: |
             brew update
+            brew unlink openssl@3
             brew link --force openssl@1.1
           CIBW_BEFORE_ALL_WINDOWS: ${{ matrix.before }}
           CIBW_BUILD_FRONTEND: build

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -69,7 +69,7 @@ jobs:
           CIBW_BEFORE_ALL_WINDOWS: ${{ matrix.before }}
           CIBW_BUILD_FRONTEND: build
           CIBW_ENVIRONMENT: ${{ matrix.env }}
-          CIBW_TEST_SKIP: "*-macosx_universal2:arm64"
+          CIBW_TEST_SKIP: "*-macosx_universal2:arm64 *-macosx_arm64 *-macosx_x86_64"
           CIBW_TEST_COMMAND: python {package}/tests.py
 
       - name: Store the distribution packages

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -68,7 +68,6 @@ jobs:
             fi
           CIBW_BEFORE_ALL_MACOS: |
             brew update
-            brew install openssl@1.1
             brew link --force openssl@1.1
           CIBW_BEFORE_ALL_WINDOWS: ${{ matrix.before }}
           CIBW_BUILD_FRONTEND: build

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -28,6 +28,9 @@ jobs:
           - os: macos-15
             arch: x86_64 arm64
             env: MACOSX_DEPLOYMENT_TARGET=15.0
+          - os: macos-14
+            arch: x86_64 arm64
+            env: MACOSX_DEPLOYMENT_TARGET=14.0
           - os: windows-2022
             arch: x86
             before: vcpkg install openssl:x86-windows-static

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -69,7 +69,7 @@ jobs:
           CIBW_BEFORE_ALL_MACOS: |
             brew update
             brew unlink openssl@3
-            brew link --force openssl@1.1
+            brew link --overwrite openssl@1.1
           CIBW_BEFORE_ALL_WINDOWS: ${{ matrix.before }}
           CIBW_BUILD_FRONTEND: build
           CIBW_ENVIRONMENT: ${{ matrix.env }}

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -26,7 +26,7 @@ jobs:
           - os: ubuntu-24.04
             arch: aarch64
           - os: macos-15
-            arch: x86_64 universal2
+            arch: x86_64 arm64
           - os: windows-2022
             arch: x86
             before: vcpkg install openssl:x86-windows-static
@@ -69,7 +69,7 @@ jobs:
           CIBW_BEFORE_ALL_WINDOWS: ${{ matrix.before }}
           CIBW_BUILD_FRONTEND: build
           CIBW_ENVIRONMENT: ${{ matrix.env }}
-          CIBW_TEST_SKIP: "*-macosx_universal2:arm64 *-macosx_arm64 *-macosx_x86_64"
+          CIBW_TEST_SKIP: "*-macosx_arm64 *-macosx_x86_64"
           CIBW_TEST_COMMAND: python {package}/tests.py
 
       - name: Store the distribution packages

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -67,7 +67,7 @@ jobs:
               apk add openssl-dev
             fi
           CIBW_BEFORE_ALL_WINDOWS: ${{ matrix.before }}
-          CIBW_BUILD_FRONTEND: "build; args: --enable-openssl"
+          CIBW_BUILD_FRONTEND: build
           CIBW_ENVIRONMENT: ${{ matrix.env }}
           CIBW_TEST_SKIP: "*-macosx_universal2:arm64"
           CIBW_TEST_COMMAND: python {package}/tests.py

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -66,6 +66,10 @@ jobs:
             elif [[ ! -z "$(which apk)" ]]; then
               apk add openssl-dev
             fi
+          CIBW_BEFORE_ALL_MACOS: |
+            brew update
+            brew install openssl@1.1
+            brew link --force openssl@1.1
           CIBW_BEFORE_ALL_WINDOWS: ${{ matrix.before }}
           CIBW_BUILD_FRONTEND: build
           CIBW_ENVIRONMENT: ${{ matrix.env }}

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -67,9 +67,9 @@ jobs:
               apk add openssl-dev
             fi
           CIBW_BEFORE_ALL_MACOS: |
-            brew update
-            brew unlink openssl@3
-            brew link --overwrite openssl@1.1
+            ls /usr/local/opt/openssl
+            ls /opt/homebrew/include
+            ls /opt/homebrew/opt/openssl/lib
           CIBW_BEFORE_ALL_WINDOWS: ${{ matrix.before }}
           CIBW_BUILD_FRONTEND: build
           CIBW_ENVIRONMENT: ${{ matrix.env }}

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -68,7 +68,7 @@ jobs:
               apk add openssl-dev
             fi
           CIBW_BEFORE_ALL_WINDOWS: ${{ matrix.before }}
-          CIBW_BUILD_FRONTEND: build
+          CIBW_BUILD_FRONTEND: "build; args: --config-setting=--enable_openssl"  
           CIBW_ENVIRONMENT: ${{ matrix.env }}
           CIBW_TEST_SKIP: "*-macosx_arm64 *-macosx_x86_64"
           CIBW_TEST_COMMAND: python {package}/tests.py

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -27,6 +27,7 @@ jobs:
             arch: aarch64
           - os: macos-15
             arch: x86_64 arm64
+            env: MACOSX_DEPLOYMENT_TARGET=15.0
           - os: windows-2022
             arch: x86
             before: vcpkg install openssl:x86-windows-static

--- a/setup.py
+++ b/setup.py
@@ -178,7 +178,7 @@ class BuildExtCommand(build_ext):
           '--enable-macho can''t be used with --dynamic-linking')
     if self.enable_openssl and self.dynamic_linking:
       raise distutils.errors.DistutilsOptionError(
-          '--enable-enable-openssl can''t be used with --dynamic-linking')
+          '--enable-openssl can''t be used with --dynamic-linking')
 
 
   def run(self):

--- a/setup.py
+++ b/setup.py
@@ -281,16 +281,18 @@ class BuildExtCommand(build_ext):
       module.libraries.append('yara')
     else:
       # Is OpenSSL available?
-      if (has_function('OPENSSL_version_major',
+      if (has_function('OpenSSL_add_all_algorithms',
+                       includes=['openssl/evp.h'],
                        include_dirs=module.include_dirs + openssl_include_dirs,
                        libraries=module.libraries + openssl_libraries,
                        library_dirs=module.library_dirs + openssl_library_dirs)
           # In case OpenSSL is being linked statically
-          or has_function('OPENSSL_version_major',
+          or has_function('OpenSSL_add_all_algorithms',
+                       includes=['openssl/evp.h'],
                        include_dirs=module.include_dirs + openssl_include_dirs,
                        libraries=module.libraries + openssl_libraries + ['dl', 'pthread', 'z'],
                        library_dirs=module.library_dirs + openssl_library_dirs)
-          or True):
+          or self.enable_openssl):
         module.define_macros.append(('HASH_MODULE', '1'))
         module.define_macros.append(('HAVE_LIBCRYPTO', '1'))
         module.libraries.extend(openssl_libraries)

--- a/setup.py
+++ b/setup.py
@@ -290,7 +290,7 @@ class BuildExtCommand(build_ext):
                        include_dirs=module.include_dirs + openssl_include_dirs,
                        libraries=module.libraries + openssl_libraries + ['dl', 'pthread', 'z'],
                        library_dirs=module.library_dirs + openssl_library_dirs)
-          or self.enable_openssl):
+          or True):
         module.define_macros.append(('HASH_MODULE', '1'))
         module.define_macros.append(('HAVE_LIBCRYPTO', '1'))
         module.libraries.extend(openssl_libraries)

--- a/setup.py
+++ b/setup.py
@@ -281,14 +281,12 @@ class BuildExtCommand(build_ext):
       module.libraries.append('yara')
     else:
       # Is OpenSSL available?
-      if (has_function('OpenSSL_add_all_algorithms',
-                       includes=['openssl/evp.h'],
+      if (has_function('OPENSSL_version_major',
                        include_dirs=module.include_dirs + openssl_include_dirs,
                        libraries=module.libraries + openssl_libraries,
                        library_dirs=module.library_dirs + openssl_library_dirs)
           # In case OpenSSL is being linked statically
-          or has_function('OpenSSL_add_all_algorithms',
-                       includes=['openssl/evp.h'],
+          or has_function('OPENSSL_version_major',
                        include_dirs=module.include_dirs + openssl_include_dirs,
                        libraries=module.libraries + openssl_libraries + ['dl', 'pthread', 'z'],
                        library_dirs=module.library_dirs + openssl_library_dirs)


### PR DESCRIPTION
macOS wheels were being linked without OpenSSL due because the build script was not able to correctly detect that the library was installed. This only happens when running inside the `cibuildwheel` container, even though OpenSSL is actually installed. 

The OpenSSL detection is bypassed by using `--enable-openssl`.